### PR TITLE
Updated low level feature set

### DIFF
--- a/src/feature_extractor.cpp
+++ b/src/feature_extractor.cpp
@@ -76,6 +76,8 @@ void FeatureExtractor::addPlayerFeatures(rcsc::PlayerObject& player,
                                          const rcsc::Vector2D& self_pos,
                                          const rcsc::AngleDeg& self_ang) {
   assert(player.posValid());
+  // Player uniform number
+  addFeature(player.unum());
   // Angle dist to player.
   addLandmarkFeatures(player.pos(), self_pos, self_ang);
   // Player's body angle

--- a/src/lowlevel_feature_extractor.h
+++ b/src/lowlevel_feature_extractor.h
@@ -16,9 +16,9 @@ public:
 
 protected:
   // Number of features for non-player objects.
-  const static int num_basic_features = 58;
+  const static int num_basic_features = 62;       
   // Number of features for each player or opponent in game.
-  const static int features_per_player = 8;
+  const static int features_per_player = 9;
 };
 
 #endif // LOWLEVEL_FEATURE_EXTRACTOR_H


### PR DESCRIPTION
Pretty straightforward. I had to disable the checkFeatures() call because the uniform numbers are not within FEAT_MIN and FEAT_MAX (I did it this way since that's how it was done in the high level set).

The document should also be updated -- I didn't do it yet in case we make more changes. Don't want to re-number all the features more than once. 
