### PR TITLE
setup.py, README.md clarifications; HFO, python_agents_3v3.sh misc improvements; prevention of endless loop for high_level_custom_agent.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ for (int episode=0; episode<5; episode++) {
 ```python
 hfo = hfo.HFOEnvironment()
 hfo.connectServer(...)
-for episode in xrange(5): # replace with range(5) for Python 3.X
+for episode in range(5): # replace with xrange(5) for Python 2.X
   status = IN_GAME
   while status == IN_GAME:
     features = hfo.getState()

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ RoboCup 2D Half Field Offense
  - Boost-system, filesystem
  - Qt4 [Required for SoccerWindow2 visualizer]: To not build the visualizer, add cmake flag `-DBUILD_SOCCERWINDOW=False`
 
+## Python Dependencies
+ - Python 2.7 or 3.2+ (tested with 2.7 and 3.5)
+ - numpy
+
 ## Install
 ```
 mkdir build && cd build
@@ -65,7 +69,7 @@ for (int episode=0; episode<5; episode++) {
 ```python
 hfo = hfo.HFOEnvironment()
 hfo.connectServer(...)
-for episode in xrange(5):
+for episode in xrange(5): # replace with range(5) for Python 3.X
   status = IN_GAME
   while status == IN_GAME:
     features = hfo.getState()

--- a/bin/HFO
+++ b/bin/HFO
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from __future__ import print_function
 
 import subprocess, os, time, numpy, sys
 
 # Global list of all/essential running processes
 processes, necProcesses = [], []
-# Command to run the rcssserver. Edit as needed.
+
+# Command to run the rcssserver. Edit as needed; the below assumes running in the same directory as HFO
 SERVER_BIN = 'rcssserver'
-# Command to run the monitor. Edit as needed.
+# Command to run the monitor. Edit as needed; ditto to the above re directories.
 MONITOR_BIN = 'soccerwindow2'
 
-def launch(cmd, name = 'Unknown', necessary = True, supressOutput = True):
+def launch(cmd, name = 'Unknown', necessary = True, suppressOutput = True):
   """Launch a process.
 
   Appends to list of processes and (optionally) necProcesses if
@@ -19,10 +21,14 @@ def launch(cmd, name = 'Unknown', necessary = True, supressOutput = True):
   Returns: The launched process.
   """
   kwargs = {}
-  if supressOutput:
+  if suppressOutput:
     kwargs = {'stdout': open('/dev/null', 'w'),
               'stderr': open('/dev/null', 'w')}
-  p = subprocess.Popen(cmd.split(' '), shell = False, **kwargs)
+  try:
+    p = subprocess.Popen(cmd.split(' '), shell = False, **kwargs)
+  except (IOError, OSError):
+    print("ERROR: Unsuccessful launch of process {!r}".format(cmd), file=sys.stderr)
+    raise
   processes.append(p)
   if necessary:
     necProcesses.append([p,name])
@@ -66,7 +72,7 @@ def main(args):
   try:
     # Launch the Server
     server = launch(serverCommand + serverOptions, name='server',
-                    supressOutput=not args.verbose)
+                    suppressOutput=not args.verbose)
     time.sleep(0.2)
     assert server.poll() is None,\
       '[start.py] Failed to launch Server with command: \"%s\"' \

--- a/example/communication_agent.py
+++ b/example/communication_agent.py
@@ -36,7 +36,7 @@ def main():
     # Quit if the server goes down
     if status == SERVER_DOWN:
       hfo.act(QUIT)
-      break
+      exit()
 
 if __name__ == '__main__':
   main()

--- a/example/example_defense_agent.py
+++ b/example/example_defense_agent.py
@@ -29,7 +29,7 @@ def main():
     # Quit if the server goes down
     if status == SERVER_DOWN:
       hfo.act(QUIT)
-      break
+      exit()
 
 if __name__ == '__main__':
   main()

--- a/example/hfo_example_agent.py
+++ b/example/hfo_example_agent.py
@@ -29,7 +29,7 @@ def main():
     # Quit if the server goes down
     if status == SERVER_DOWN:
       hfo.act(QUIT)
-      break
+      exit()
 
 if __name__ == '__main__':
   main()

--- a/example/high_level_custom_agent.py
+++ b/example/high_level_custom_agent.py
@@ -56,7 +56,7 @@ def get_action(state,hfo_env,num_teammates):
     hfo_env.act(DRIBBLE)
     return
   # If nothing can be done pass
-  hfo_env.act(PASS)
+  hfo_env.act(PASS) # doesn't this require a target teammate?
     
 
 def main():

--- a/example/high_level_custom_agent.py
+++ b/example/high_level_custom_agent.py
@@ -86,7 +86,7 @@ def main():
       #print(status)
       if status == SERVER_DOWN:
         hfo_env.act(QUIT)
-        break 
+        exit()
   
 
 if __name__ == '__main__':

--- a/example/high_level_custom_agent.py
+++ b/example/high_level_custom_agent.py
@@ -52,11 +52,14 @@ def get_action(state,hfo_env,num_teammates):
                       curr_goal_angle = goal_op_angle):
       hfo_env.act(PASS, teammate_uniform_number)
       return
+  # not sure if below check is needed - doDribble in agent.cpp includes
+  # (via doPreprocess) doForceKick, which may cover this situation depending
+  # on what existKickableOpponent returns.
   if can_dribble(dist_to_op = state[9]):
     hfo_env.act(DRIBBLE)
     return
-  # If nothing can be done pass
-  hfo_env.act(PASS) # doesn't this require a target teammate?
+  # If nothing can be done, do not do anything
+  hfo_env.act(NOOP)
     
 
 def main():

--- a/example/high_level_random_agent.py
+++ b/example/high_level_random_agent.py
@@ -32,7 +32,7 @@ def main():
     # Quit if the server goes down
     if status == SERVER_DOWN:
       hfo.act(QUIT)
-      break
+      exit()
 
 if __name__ == '__main__':
   main()

--- a/example/python_agents_3v3.sh
+++ b/example/python_agents_3v3.sh
@@ -2,9 +2,10 @@
 
 ./bin/HFO --offense-agents=2 --defense-npcs=3 --offense-npcs=1 --trials 20 --headless &
 sleep 5
-/usr/bin/python2.7 ./example/high_level_custom_agent.py --numTeammates=2 --numOpponents=3 --port 6000 &> agent1.txt &
+# -x is needed to skip first line - otherwise whatever default python version is will run
+python2.7 -x ./example/high_level_custom_agent.py --numTeammates=2 --numOpponents=3 --port 6000 &> agent1.txt &
 sleep 5
-/usr/bin/python3 ./example/high_level_custom_agent.py --numTeammates=2 --numOpponents=3 --port 6000 &> agent2.txt &
+python3 -x ./example/high_level_custom_agent.py --numTeammates=2 --numOpponents=3 --port 6000 &> agent2.txt &
 
 # The magic line
 #   $$ holds the PID for this script

--- a/hfo/hfo.py
+++ b/hfo/hfo.py
@@ -116,14 +116,12 @@ class HFOEnvironment(object):
     hfo_lib.getState(self.obj, as_ctypes(state_data))
     return state_data
 
-  def act(self, *args):
+  def act(self, action_type, *args):
     """ Performs an action in the environment """
-    assert len(args) > 0, 'Not enough arguments provided to act'
-    action_type = args[0]
     n_params = hfo_lib.numParams(action_type)
-    assert n_params == len(args) - 1, 'Incorrect number of params to act: '\
-      'Required %d, provided %d'%(n_params, len(args)-1)
-    params = np.asarray(args[1:], dtype=np.float32)
+    assert n_params == len(args), 'Incorrect number of params to act: '\
+      'Required %d, provided %d'%(n_params, len(args))
+    params = np.asarray(args, dtype=np.float32)
     hfo_lib.act(self.obj, action_type, params.ctypes.data_as(POINTER(c_float)))
 
   def say(self, message):
@@ -144,11 +142,11 @@ class HFOEnvironment(object):
 
   def actionToString(self, action):
     """ Returns a string representation of an action """
-    return hfo_lib.actionToString(action.decode('utf-8'))
+    return hfo_lib.actionToString(action).decode('utf-8')
 
   def statusToString(self, status):
     """ Returns a string representation of a game status """
-    return hfo_lib.statusToString(status)
+    return hfo_lib.statusToString(status).decode('utf-8')
 
   def getUnum(self):
     """ Return the uniform number of the agent """

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,16 @@ setup(name = 'hfo',
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
+        'Operating System :: OS Independent', # except for shell scripts
+        'Programming Language :: C++',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2', # not tested
+        'Programming Language :: Python :: 3.3', # not tested
+        'Programming Language :: Python :: 3.4', # not tested
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6', # not tested
       ],
+      requires=['numpy'],
       # packages=find_packages(),
       packages=['hfo'],
       package_dir={'hfo': 'hfo'},


### PR DESCRIPTION
I did a bit of testing and checking, and found that it will definitely run on 2.7 and 3.5 (add others that you've tested locally, of course), but the python HFO script will not run on 3.0 or 3.1 (no argparse module). I have also noted a requirement for numpy.

I've also done a bit of reliability improvements for HFO, and enabled better using python_agents_3v3.sh for testing.

-Allen