### PR TITLE
Add ball y parameters for HFORef::resetField()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ find_package(FLEX REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 ExternalProject_Add(rcssserver
-#  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
-  GIT_REPOSITORY "https://github.com/wbwatkinson/rcssserver.git"
+  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
   GIT_TAG "master"
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=MinSizeRel
   UPDATE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(FLEX REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 ExternalProject_Add(rcssserver
-  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
+#  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
+  GIT_REPOSITORY "https://github.com/wbwatkinson/rcssserver.git"
   GIT_TAG "master"
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=MinSizeRel
   UPDATE_COMMAND ""
@@ -109,7 +110,7 @@ list(APPEND RCSC_LINK_LIBS rcsc_agent rcsc_geom rcsc_param rcsc_ann rcsc_net rcs
 
 add_library(player_chain_action STATIC ${PLAYER_SOURCES} ${CHAIN_ACTION_SOURCES})
 add_executable(sample_coach ${SOURCE_DIR}/main_coach.cpp ${SOURCE_DIR}/sample_coach.cpp)
-add_executable(sample_player ${SOURCE_DIR}/HFO.cpp ${SOURCE_DIR}/main_player.cpp ${SOURCE_DIR}/sample_player.cpp ${SOURCE_DIR}/agent.cpp) 
+add_executable(sample_player ${SOURCE_DIR}/HFO.cpp ${SOURCE_DIR}/main_player.cpp ${SOURCE_DIR}/sample_player.cpp ${SOURCE_DIR}/agent.cpp)
 add_executable(sample_trainer ${SOURCE_DIR}/main_trainer.cpp ${SOURCE_DIR}/sample_trainer.cpp)
 add_executable(agent ${SOURCE_DIR}/HFO.cpp ${SOURCE_DIR}/main_agent.cpp ${SOURCE_DIR}/agent.cpp)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/teams/base)

--- a/bin/HFO
+++ b/bin/HFO
@@ -78,6 +78,8 @@ def main(args):
                   'server::hfo_max_untouched_time=%i ' \
                   'server::hfo_min_ball_pos_x=%f ' \
                   'server::hfo_max_ball_pos_x=%f ' \
+                  'server::hfo_min_ball_pos_y=%f ' \
+                  'server::hfo_max_ball_pos_y=%f ' \
                   'server::say_msg_size=%i ' \
                   'server::record_messages=%i' \
                   %(server_port, coach_port, olcoach_port,
@@ -86,7 +88,9 @@ def main(args):
                     args.sync, args.fullstate, args.fullstate,
                     args.maxFramesPerTrial, args.numTrials, args.numFrames,
                     args.offenseOnBall, args.seed, args.maxUntouchedTime,
-                    args.min_ball_x, args.max_ball_x, args.messageSize,
+                    args.min_ball_x, args.max_ball_x,
+                    args.min_ball_y, args.max_ball_y,
+                    args.messageSize,
                     args.verbose)
 
   try:

--- a/bin/HFO
+++ b/bin/HFO
@@ -159,7 +159,7 @@ def parseArgs():
   p.add_argument('--agent-play-goalie', dest='agentPlayGoalie', action='store_true',
                  default=False, help='Defense-agent plays goalie, rather than defender.')
   p.add_argument('--offense-team', dest='offenseTeam', type=str, default='base',
-                 help='Offense team binary. Options: '+str(installed_teams)+'. Default: base.') 
+                 help='Offense team binary. Options: '+str(installed_teams)+'. Default: base.')
   p.add_argument('--defense-team', dest='defenseTeam', type=str, default='base',
                  help='Defense team binary. Options: '+str(installed_teams)+'. Default: base.')
   p.add_argument('--no-sync', dest='sync', action='store_false', default=True,
@@ -192,6 +192,10 @@ def parseArgs():
                  help='Ball initialization min x position: [0,1]. Default: 0')
   p.add_argument('--ball-x-max', dest='max_ball_x', type=float, default=0.2,
                  help='Ball initialization max x position: [0,1]. Default: .2')
+  p.add_argument('--ball-y-min', dest='min_ball_y', type=float, default=-0.8,
+                 help='Ball initialization min y position: [-1,1]. Default: -0.8')
+  p.add_argument('--ball-y-max', dest='max_ball_y', type=float, default=0.8,
+                 help='Ball initialization max y position: [-1,1]. Default: 0.8')
   p.add_argument('--verbose', dest='verbose', action='store_true',
                  default=False, help='Print verbose output.')
   args = p.parse_args()


### PR DESCRIPTION
This PR works in conjunction with a proposed PR for [mhauskn/rcssserver](https://github.com/mhauskn/rcssserver/pull/8) that adds the option of setting min y and max y ball position from the command line. The range of these values is -1.0 to 1.0 which corresponds to the top of the field to the bottom of the field, respectively. Without setting these at the command line, the default behavior is unchanged, where the ball is placed vertically in the mid-80% of the field.