### PR TITLE
HLFS + Sarsa Agent

### DIFF
--- a/example/sarsa_offense/high_level_sarsa_agent.py
+++ b/example/sarsa_offense/high_level_sarsa_agent.py
@@ -8,10 +8,6 @@ import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'sarsa_libraries','python_wrapper'))
 from py_wrapper import *
 
-NA=0      #Number of actions
-NOT=0     #Number of teammates
-NF=0      #Number of features
-
 def getReward(s):
   reward=0
   #--------------------------- 
@@ -44,7 +40,7 @@ def purge_features(state):
   tmpIndex= 9 + 3*NOT
   for i in range(len(state)):
     # Ignore first six features and teammate proximity to opponent(when opponent is absent)and opponent features
-    if(i < 6 or i>9+6*NOT or (args.numOpponents==0 and ((i>9+numTMates and i<=9+2*numTMates) or i==9)) ): 
+    if(i < 6 or i>9+6*NOT or (NOO==0 and ((i>9+NOT and i<=9+2*NOT) or i==9)) ): 
       continue;
     #Ignore Angle and Uniform Number of Teammates
     temp =  i-tmpIndex;
@@ -71,7 +67,8 @@ if __name__ == '__main__':
   hfo = HFOEnvironment()
   #now connect to the server
   hfo.connectToServer(HIGH_LEVEL_FEATURE_SET,'bin/teams/base/config/formations-dt',args.port,'localhost','base_left',False)
-  global NF,NA, NOT
+  global NF,NA,NOT,NOO
+  NOO=args.numOpponents
   if args.numOpponents >0: 
     NF=4+4*args.numTeammates
   else:
@@ -85,7 +82,7 @@ if __name__ == '__main__':
   Min=[-1]*NF
   Res=[resolution]*NF
   #Sarsa Agent Parameters
-  wt_filename="weights_"+str(NOT+1)+"v"+str(args.numOpponents)+'_'+str(args.suffix)
+  wt_filename="weights_"+str(NOT+1)+"v"+str(NOO)+'_'+str(args.suffix)
   discFac=1
   Lambda=0
   eps=0.01

--- a/example/simulate_python_sarsa_agents.sh
+++ b/example/simulate_python_sarsa_agents.sh
@@ -37,7 +37,7 @@ output_path=$agent_path
 agent_filename="high_level_sarsa_agent.py"
 
 #start the server
-stdbuf -oL ./bin/HFO --port=$port --no-logging --offense-agents=$oa --defense-npcs=$da --trials=$trials --defense-team=base  --headless --fullstate  > $log_dir/"$oa"v"$da""_sarsa_py_agents.log" &
+stdbuf -oL ./bin/HFO --port=$port --no-logging --offense-agents=$oa --defense-npcs=$da --trials=$trials --defense-team=base --fullstate  --headless > $log_dir/"$oa"v"$da""_sarsa_py_agents.log" &
 
 #each agent is a seperate process
 for n in $(seq 1 $oa)
@@ -48,7 +48,7 @@ do
     fname+=".txt"
     logfile=$log_dir/$fname
     rm $logfile
-    $python $agent_path/$agent_filename --port=$port --numTeammates=`expr $oa - 1` --numOpponents=$da --numEpisodes=$trials &> $log_dir/$fname &
+    $python $agent_path/$agent_filename --port=$port --numTeammates=`expr $oa - 1` --numOpponents=$da --numEpisodes=$trials --suffix=$n &> $log_dir/$fname &
 done
     
 # The magic line

--- a/src/highlevel_feature_extractor.h
+++ b/src/highlevel_feature_extractor.h
@@ -23,6 +23,10 @@ public:
   virtual const std::vector<float>& ExtractFeatures(const rcsc::WorldModel& wm,
 						    bool last_action_status);
 
+  //override FeatureExtractor::valid
+  //this method takes a pointer instead of a reference
+  static bool valid(const rcsc::PlayerObject* player);
+
 protected:
   // Number of features for non-player objects.
   const static int num_basic_features = 10;


### PR DESCRIPTION
This PR fixes Issue #56. The teammate and opponent features are now ordered according to proximity from the agent. This is in congruence with the ordering of the low level feature set.

In addition, there are also minor bug fixes to the python sarsa agent and the associated shell script.
These significantly bring down the performance gap mentioned in Issue #52 