### PR TITLE
Partial Observability in High Level Features

### DIFF
--- a/src/highlevel_feature_extractor.cpp
+++ b/src/highlevel_feature_extractor.cpp
@@ -91,7 +91,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
   int detected_teammates = 0;
   for (PlayerPtrCont::const_iterator it=teammates.begin(); it != teammates.end(); ++it) {
     const PlayerObject* teammate = *it;
-    if (valid(teammate) && detected_teammates < numTeammates) {
+    if (valid(teammate) && teammate->unum() > 0 && detected_teammates < numTeammates) {
       addNormFeature(calcLargestGoalAngle(wm, teammate->pos()), 0, M_PI);
       detected_teammates++;
     }
@@ -106,7 +106,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
     detected_teammates = 0;
     for (PlayerPtrCont::const_iterator it=teammates.begin(); it != teammates.end(); ++it) {
       const PlayerObject* teammate = *it;
-      if (valid(teammate) && detected_teammates < numTeammates) {
+      if (valid(teammate) && teammate->unum() > 0 && detected_teammates < numTeammates) {
         calcClosestOpp(wm, teammate->pos(), th, r);
         addNormFeature(r, 0, maxR);
         detected_teammates++;
@@ -126,7 +126,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
   detected_teammates = 0;
   for (PlayerPtrCont::const_iterator it=teammates.begin(); it != teammates.end(); ++it) {
     const PlayerObject* teammate = *it;
-    if (valid(teammate) && detected_teammates < numTeammates) {
+    if (valid(teammate) && teammate->unum() > 0 && detected_teammates < numTeammates) {
       addNormFeature(calcLargestTeammateAngle(wm, self_pos, teammate->pos()),0,M_PI);
       detected_teammates++;
     }
@@ -140,7 +140,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
   detected_teammates = 0;
   for (PlayerPtrCont::const_iterator it=teammates.begin(); it != teammates.end(); ++it) {
     const PlayerObject* teammate = *it;
-    if (valid(teammate) && detected_teammates < numTeammates) {
+    if (valid(teammate) && teammate->unum() > 0 && detected_teammates < numTeammates) {
       if (playingOffense) {
         addNormFeature(teammate->pos().x, -tolerance_x, SP.pitchHalfLength() + tolerance_x);
       } else {
@@ -162,7 +162,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
   int detected_opponents = 0;
   for (PlayerPtrCont::const_iterator it = opponents.begin(); it != opponents.end(); ++it) {
     const PlayerObject* opponent = *it;
-    if (valid(opponent) && detected_opponents < numOpponents) {
+    if (valid(opponent) && opponent->unum() > 0 && detected_opponents < numOpponents) {
       if (playingOffense) {
         addNormFeature(opponent->pos().x, -tolerance_x, SP.pitchHalfLength() + tolerance_x);
       } else {

--- a/src/highlevel_feature_extractor.h
+++ b/src/highlevel_feature_extractor.h
@@ -25,7 +25,7 @@ public:
 
   //override FeatureExtractor::valid
   //this method takes a pointer instead of a reference
-  static bool valid(const rcsc::PlayerObject* player);
+  bool valid(const rcsc::PlayerObject* player);
 
 protected:
   // Number of features for non-player objects.


### PR DESCRIPTION
In line with the convention adopted by the low level feature set, a teammate or opponent should - either or not - be completely observable  [even when the fullstate flag is OFF].

Currently, quite often, an agent is able to observe the positional and other information of an opponent or teammate - however it is not able to observe its uniform number.  Essentially it can sense [albeit noisily] the position of a player and yet be completely unaware of who that it. This should not be logically possible.

This PR fixes this issue in a way that is consistent with the approach adopted by the low level feature extractor.