### PR TITLE
Stamina

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ install:
        brew install cartr/qt4/qt 
        ;
     fi
-  - sudo -H pip install --upgrade nose numpy
+  - sudo -H pip2 install --upgrade nose numpy
+  - sudo -H pip3 install --upgrade nose numpy
 os:
   - linux
   - osx
@@ -27,4 +28,4 @@ env:
 script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=RelwithDebInfo .. && make -j4 && make install
-  - cd .. && pip install --user . && nosetests --exe -vd tests/test_basic.py
+  - cd .. && pip3 install --user . && nosetests --exe -vd tests/test_basic.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
        ;
     fi
   - sudo -H pip2 install --upgrade nose numpy
-  - sudo -H pip3 install --upgrade nose numpy
 os:
   - linux
   - osx
@@ -28,4 +27,4 @@ env:
 script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=RelwithDebInfo .. && make -j4 && make install
-  - cd .. && pip3 install --user . && nosetests --exe -vd tests/test_basic.py
+  - cd .. && pip2 install --user . && nosetests --exe -vd tests/test_basic.py

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -286,7 +286,7 @@ follows:
 
 \subsubsection{High Level State Feature List}
 Let $T$ denote the number of teammates in the HFO game and $O$ the
-number of opponents. There are a total of $10 + 6T + 3O$ high-level
+number of opponents. There are a total of $10 + 6T + 3O + 2$ high-level
 features.
 
 \begin{enumerate}[noitemsep]
@@ -328,6 +328,7 @@ features.
 	the last action taken was successful, either in accomplishing the
 	usual intent of the action or (primarily for the offense) in some other way such as
 	getting out of a goal-collision state. 1 for yes, -1 for no.}
+\item [$+1$] {\textbf{Stamina} Agent's Stamina: Low stamina slows movement.}
 \end{enumerate}
 
 \begin{figure}[htp]
@@ -468,7 +469,7 @@ the above categories. These features are referred to as \textit{other
 
 \subsubsection{Low Level State Feature List}
 Let $T$ denote the number of teammates and $O$ denote the number of
-opponents in the HFO game. Then there are a total of $58 + 9T + 9O$
+opponents in the HFO game. Then there are a total of $58 + 9T + 9O + 1$
 low-level features:
 
 \begin{enumerate}[noitemsep]

--- a/src/highlevel_feature_extractor.cpp
+++ b/src/highlevel_feature_extractor.cpp
@@ -16,7 +16,7 @@ HighLevelFeatureExtractor::HighLevelFeatureExtractor(int num_teammates,
   assert(numOpponents >= 0);
   numFeatures = num_basic_features + features_per_teammate * numTeammates
       + features_per_opponent * numOpponents;
-  numFeatures++; // action status
+  numFeatures+=2; // action status, stamina
   feature_vec.resize(numFeatures);
 }
 
@@ -185,6 +185,7 @@ HighLevelFeatureExtractor::ExtractFeatures(const rcsc::WorldModel& wm,
   } else {
     addFeature(FEAT_MIN);
   }
+  addNormFeature(self.stamina(), 0., observedStaminaMax);
 
   assert(featIndx == numFeatures);
   // checkFeatures();


### PR DESCRIPTION
This PR adds stamina to the high level feature set.

It is important for agents that are not following the default Agent 2D strategy [i.e. MOVE action] when not in possession of the ball, to know their own stamina. Otherwise, alternative movement strategies built from sequences of MOVE_TO(x,y) actions suffer from agents getting exhausted (as indicated 0-8000 stamina value in the visualiser)