### PR TITLE
Keep behavior same as pip package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(FLEX REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 ExternalProject_Add(rcssserver
-  GIT_REPOSITORY "https://github.com/fizzxed/rcssserver.git"
+  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
   GIT_TAG "master"
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=MinSizeRel
   UPDATE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(FLEX REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 ExternalProject_Add(rcssserver
-  GIT_REPOSITORY "https://github.com/mhauskn/rcssserver.git"
+  GIT_REPOSITORY "https://github.com/fizzxed/rcssserver.git"
   GIT_TAG "master"
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=MinSizeRel
   UPDATE_COMMAND ""

--- a/hfo/__init__.py
+++ b/hfo/__init__.py
@@ -1,1 +1,15 @@
 from .hfo import *
+
+import os
+
+def get_hfo_path():
+  package_directory = os.path.dirname(os.path.abspath(__file__))
+  return os.path.join(package_directory, 'bin/HFO')
+
+def get_viewer_path():
+  package_directory = os.path.dirname(os.path.abspath(__file__))
+  return os.path.join(package_directory, 'bin/soccerwindow2')
+
+def get_config_path():
+  package_directory = os.path.dirname(os.path.abspath(__file__))
+  return os.path.join(package_directory, 'bin/teams/base/config/formations-dt')


### PR DESCRIPTION
compiling from this repo does not give access to `get_hfo_path()`, `get_viewer_path()`, and `get_config_path()` as the pip package from: https://github.com/mhauskn/hfo-py does. Fixes this.