### PR TITLE
added sleep between server start and agent connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ forwards slowly. First start the server: `./bin/HFO --offense-agents=1
 
 Or do both in a single command:
 ```
-(./bin/HFO --offense-agents=1 --no-sync &) && ./example/hfo_example_agent
+(./bin/HFO --offense-agents=1 --no-sync &) && sleep 1 && ./example/hfo_example_agent
 ```
 
 ## Example Agents


### PR DESCRIPTION
If I start the server and connect an agent in the same command line, as stated in the README, the agent does not connect to the server, stating:

```
$ (./bin/HFO --offense-agents=1 --no-sync &) && ./example/hfo_example_agent

[...]

Waiting for player-controlled agent base_left-0: config_dir=/home/user/Code/HFO/bin/teams/base/config/formations-dt, server_port=6000, server_addr=localhost, team_name=base_left, play_goalie=False
 -1: waited 5 seconds. server down??
[ConnectToServer] Server Down!
```

By adding a call to `sleep` between the command that starts the server and the one that connects the agent, this error does not occur:

    $ (./bin/HFO --offense-agents=1 --no-sync &) && sleep 1 && ./example/hfo_example_agent